### PR TITLE
fix: contrast color on terminals that don't fallback to contrast foreground color by default

### DIFF
--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -24,7 +24,7 @@ const baseTheme: Theme = {
 };
 
 const tui = new Tui({
-  style: crayon.bgBlack,
+  style: crayon.bgBlack.white,
   canvas: new Canvas({
     refreshRate: 1000 / 60,
     size: await Deno.consoleSize(Deno.stdout.rid),
@@ -276,8 +276,8 @@ queueMicrotask(() => {
       component,
       framePieces: "rounded",
       theme: {
-        base: crayon.bgBlack.white,
-        focused: crayon.bgBlack.bold,
+        base: crayon.white,
+        focused: crayon.bold,
       },
     });
   }

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -24,7 +24,7 @@ const baseTheme: Theme = {
 };
 
 const tui = new Tui({
-  style: crayon.bgHex(0x333333),
+  style: crayon.bgBlack,
   canvas: new Canvas({
     refreshRate: 1000 / 60,
     size: await Deno.consoleSize(Deno.stdout.rid),
@@ -276,8 +276,8 @@ queueMicrotask(() => {
       component,
       framePieces: "rounded",
       theme: {
-        base: crayon.bgHex(0x333333).white,
-        focused: crayon.bgHex(0x333333).bold,
+        base: crayon.bgBlack.white,
+        focused: crayon.bgBlack.bold,
       },
     });
   }


### PR DESCRIPTION
Resolves #7 for the time being.

See attachment for fix in action:
![image](https://user-images.githubusercontent.com/79608594/183491758-44c1a701-a15a-4d82-9a73-feaff49c977c.png)

...It's not great, but it's still better than *no* color contrast.