### PR TITLE
fix: Add TableComponent to `src/components/mod.ts`

### DIFF
--- a/src/components/mod.ts
+++ b/src/components/mod.ts
@@ -9,5 +9,6 @@ export * from "./label.ts";
 export * from "./progress_bar.ts";
 export * from "./scrollable_view.ts";
 export * from "./slider.ts";
+export * from "./table.ts";
 export * from "./textbox.ts";
 export * from "./view.ts";


### PR DESCRIPTION
Add TableCompnent since it is not listed in the `src/components/mod.ts` file.

I tried to import a TableCompnent from `https://deno.land/x/tui@version/src/components/mod.ts`, but it is not exist.
I will add it as it is probably an omission.