### PR TITLE
fix: prevents table from throwing with negative numbers in .repeat()

### DIFF
--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -235,7 +235,9 @@ export class Table extends Component {
         let value = "";
 
         for (const header of headers) {
-          value += header.title + " ".repeat(header.width + 1 - textWidth(header.title));
+          // Ensures non-negative numbers
+          const endPadding = Math.max(0, header.width + 1 - textWidth(header.title));
+          value += header.title + " ".repeat(endPadding);
         }
 
         return value;


### PR DESCRIPTION
fixes a problem where a table component sometimes crashes because a negative number is passed to `" ".repeat()`