### PR TITLE
 fix: prevents table from throwing with negative numbers in .repeat()

### DIFF
--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -393,7 +393,7 @@ export class Table extends Component {
             prevData = dataCell;
           }
 
-          const endPadding = Math.max(0, this.rectangle.value.width - textWidth(string) - 2);          
+          const endPadding = Math.max(0, this.rectangle.value.width - textWidth(string) - 2);
           string += " ".repeat(endPadding);
           return string;
         }),

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -235,7 +235,9 @@ export class Table extends Component {
         let value = "";
 
         for (const header of headers) {
-          value += header.title + " ".repeat(header.width + 1 - textWidth(header.title));
+          // Ensures non-negative numbers
+          const endPadding = Math.max(0, header.width + 1 - textWidth(header.title));
+          value += header.title + " ".repeat(endPadding);
         }
 
         return value;

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -385,12 +385,16 @@ export class Table extends Component {
           let string = "";
           let prevData = "";
           for (const [j, dataCell] of dataRow.entries()) {
-            if (j !== 0) string += " ".repeat(headers[j - 1].width - textWidth(prevData) + 1);
+            if (j !== 0) {
+              const padding = Math.max(0, headers[j - 1].width - textWidth(prevData) + 1);
+              string += " ".repeat(padding);
+            }
             string += dataCell;
             prevData = dataCell;
           }
 
-          string += " ".repeat(this.rectangle.value.width - textWidth(string) - 2);
+          const endPadding = Math.max(0, this.rectangle.value.width - textWidth(string) - 2);          
+          string += " ".repeat(endPadding);
           return string;
         }),
         rectangle: new Computed(() => {


### PR DESCRIPTION
fixes a problem where a table component sometimes crashes because a negative number is passed to `" ".repeat()`. Continuation of #40 since i missed some lines